### PR TITLE
Update dev-requirements.txt for certifi, a dep of requests.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,3 +24,9 @@ bleach==4.1.0 # This dependency was updated to a breaking version.
 codespell==2.1.0
 requests==2.31.0
 ruamel.yaml==0.17.21
+
+
+# Pin certifi, a dependency of requests 2.31.0 pending future update of requests.
+# Current certifi==2023.5.7 has a CVE that blocks serious docker deployments...
+# https://scout.docker.com/vulnerabilities/id/CVE-2023-37920
+certifi==2023.7.22


### PR DESCRIPTION
# Description

Temporary pin of certifi

Fixes CVE issue preventing docker deployments widely

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Not tested - proposing for team to test.

# Does This PR Require a Contrib Repo Change?

Added a temporary pin to certifi, pending an update to requests.


